### PR TITLE
fix FBDEV_PATH

### DIFF
--- a/lv_drv_conf.h
+++ b/lv_drv_conf.h
@@ -320,7 +320,7 @@
 #endif
 
 #if USE_FBDEV
-#  define FBDEV_PATH          "/dev/fb1"
+#  define FBDEV_PATH          "/dev/fb0"
 #endif
 
 /*-----------------------------------------


### PR DESCRIPTION
The path for the framebuffer of CM4 is not `/dev/fb1` but `/dev/fb0`.